### PR TITLE
Alert people to not use the add-on if they are not in Pterodactyl version v1.9.x

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -3,6 +3,10 @@
 ### Need some help? ℹ️
 Please contact me on [Discord](https://discord.com/invite/qttGR4Z5Pk) if you run into any issues during installation.
 
+# BEFORE INSTALLING ⚠️
+
+This add-on will not work that are not in version v1.9.x. If you want to use this plugin manager, consider using Jexactyl. https://jexactyl.com
+
 ## Automatic Installation 📥
 
 Download and run the bash script provided in this repository to install files.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@ Please contact me on [Discord](https://discord.com/invite/qttGR4Z5Pk) if you run
 
 # BEFORE INSTALLING ⚠️
 
-This add-on will not work that are not in version v1.9.x. If you want to use this plugin manager, consider using Jexactyl. https://jexactyl.com
+This add-on will not work on Pterodactyl versions higher or lower than v1.9.x. If you still want to use this plugin manager, consider using Jexactyl. https://jexactyl.com
 
 ## Automatic Installation 📥
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Logo Image](https://cdn.discordapp.com/attachments/1012411945141424218/1012430446556090468/JexactylBannerBasic.jpg)](https://jexactyl.com)
 # Spigot Plugin Manager (v1) ⛏️
 
+# PLEASE READ THE VERSION COMPABILITY BEFORE INSTALLING
 ℹ️ *Designed for Pterodactyl v1.9.x and is featured in Jexactyl v3.2.x and onwards.*
 
 This addon allows users to search for and download plugins from the Spigot API.
@@ -23,6 +24,7 @@ Follow the steps in [INSTALL.md](INSTALL.md) for instructions.
 If you're looking for a more advanced system, you should definitely check out:
 - https://pterodactylmarket.com/resource/406
 - https://pterodactylmarket.com/resource/142
+- https://pterodactylmarket.com/resource/326
 
 ***
 

--- a/auto-install.sh
+++ b/auto-install.sh
@@ -1,6 +1,18 @@
 #!/bin/sh
 # Copyright (c) 2022 Jexactyl Development.
 
+# Alert users that they are installing a add-on that is from v1.9 (credits to Docker for giving this idea)
+echo "⚠️ This add-on will only work in Pterodactyl v1.9.x."
+echo "Due to the outdated code and multiple updates to the Pterodactyl's code, this add-on will NOT work in any version above or below 1.9.x."
+echo 
+echo "You can still install this add-on, but your Pterodactyl installation will break if you are not in Pterodactyl 1.9.x."
+echo "⚠️ To cancel this installation and keep your Pterodactyl installation working, feel free to exit this script using Control+C."
+echo 
+echo "If you want to use this plugin manager, it is included on Jexactyl v3.2 and higher. Install it using https://jexactyl.com."
+echo 
+echo "This message will expire in 20 seconds."
+sleep 20
+
 # Update dependencies
 apt update
 apt -y upgrade


### PR DESCRIPTION
Some people don't read the project's readme and decides to install it anyway without reading the prerequisites. That's why some Pterodactyl install's are broken. This pull request adds a little warning to the script, adds a 20 second timeout and alerts users that the add-on is no longer maintained and they should consider using a paid add-on or use Jexactyl.